### PR TITLE
Olympians-  GET api/v1/olympians?age=oldest

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   production: {
     client: 'pg',
-    connection: '',
+    connection: 'postgres://vyljubzbxkiexc:436f30c9296f14226e9b6177511b63fae336c179648d2cce0a6d0400d89b7a73@ec2-3-220-86-239.compute-1.amazonaws.com:5432/defgd9276a7pnu',
     migrations: {
       directory: './db/migrations'
     },

--- a/routes/api/v1/olympians.js
+++ b/routes/api/v1/olympians.js
@@ -19,8 +19,37 @@ async function allOlympians() {
   }
 }
 
+async function oldestOlympian() {
+  try {
+    let response = await database('olympians')
+      .select('name', 'team', 'age', 'sport')
+      .groupBy('name', 'team', 'age', 'sport')
+      .count('medal as total_medals_won')
+      .orderBy('age', 'desc')
+      .first()
+
+    return response;
+  } catch(err) {
+    return err;
+  }
+}
+
 router.get('/', (request, response) => {
-  allOlympians()
+  if(request.query.age === 'oldest') {
+    oldestOlympian()
+      .then(olympians => {
+        if (olympians) {
+          var data = [olympians]
+          response.status(200).send({data})
+        } else {
+          response.status(404).json({
+            error: `No olympians found`
+          });
+        }
+      })
+  }
+  else {
+    allOlympians()
     .then(olympians => {
       if (olympians.length) {
         var data = {olympians: olympians}
@@ -31,6 +60,7 @@ router.get('/', (request, response) => {
         });
       }
     })
+  }
   });
 
   module.exports = router;

--- a/tests/olympians.spec.js
+++ b/tests/olympians.spec.js
@@ -12,8 +12,8 @@ describe('Test GET api/v1/olympians', () => {
      await database.raw('truncate table olympians cascade');
 
      await database('olympians').insert([
-     {name: 'You', sex: 'M', age: 31, height: 1680, weight: 55, team: 'Australia', games: '2016 Summer', sport: 'Running', event: "Running Fast", medal: 'Silver'},
-     {name: 'Someone Else', sex: 'F', age: 24, height: 168, weight: 55, team: 'Australia', games: '2016 Summer', sport: 'Running', event: "Running the Fastest", medal: 'Platinum'},
+     {name: 'You', sex: 'M', age: 1, height: 1680, weight: 55, team: 'Australia', games: '2016 Summer', sport: 'Running', event: "Running Fast", medal: 'Silver'},
+     {name: 'Someone Else', sex: 'F', age: 23, height: 168, weight: 55, team: 'Australia', games: '2016 Summer', sport: 'Running', event: "Running the Fastest", medal: 'Platinum'},
      {name: 'Me', sex: 'F', age: 24, height: 168, weight: 55, team: 'Australia', games: '2016 Summer', sport: 'Running', event: "Running Fast", medal: 'Gold'}
    ]);
   });
@@ -29,10 +29,10 @@ describe('Test GET api/v1/olympians', () => {
       expect(res.statusCode).toBe(200)
 
       expect(res.body.olympians[2]).toHaveProperty('name')
-      expect(res.body.olympians[2].name).toBe("Me")
+      expect(res.body.olympians[2].name).toBe("You")
 
       expect(res.body.olympians[2]).toHaveProperty('age')
-      expect(res.body.olympians[2].age).toBe(24)
+      expect(res.body.olympians[2].age).toBe(1)
 
       expect(res.body.olympians[2]).toHaveProperty('team')
       expect(res.body.olympians[2].team).toBe("Australia")
@@ -43,6 +43,29 @@ describe('Test GET api/v1/olympians', () => {
 
       expect(res.body.olympians[2]).toHaveProperty('total_medals_won')
       expect(res.body.olympians[2].total_medals_won).toBe('1')
+    })
+
+    it('should get oldest olympian', async() => {
+
+      const res = await request(app).get("/api/v1/olympians?age=oldest")
+
+      expect(res.statusCode).toBe(200)
+
+      expect(res.body.data[0]).toHaveProperty('name')
+      expect(res.body.data[0].name).toBe("Me")
+
+      expect(res.body.data[0]).toHaveProperty('age')
+      expect(res.body.data[0].age).toBe(24)
+
+      expect(res.body.data[0]).toHaveProperty('team')
+      expect(res.body.data[0].team).toBe("Australia")
+
+
+      expect(res.body.data[0]).toHaveProperty('sport')
+      expect(res.body.data[0].sport).toBe("Running")
+
+      expect(res.body.data[0]).toHaveProperty('total_medals_won')
+      expect(res.body.data[0].total_medals_won).toBe('1')
 
 
 


### PR DESCRIPTION
User can make a GET request to the endpoint api/v1/olympians?age=oldest.

 - Added conditional to api/v1/olympians route for age
- creates oldestOlympian helper function in olympian router
- Testing finished with 90% coverage

- Request
```
GET api/v1/olympians?age=oldest
```
- Successful Response
```
{
  [
    {
      "name": "Julie Brougham",
      "team": "New Zealand",
      "age": 62,
      "sport": "Equestrianism"
      "total_medals_won": 0
    }
  ]
}
```