### PR TITLE
Olympians- GET api/v1/olympians?age=oldest

### DIFF
--- a/routes/api/v1/olympians.js
+++ b/routes/api/v1/olympians.js
@@ -34,9 +34,37 @@ async function oldestOlympian() {
   }
 }
 
+async function youngestOlympian() {
+  try {
+    let response = await database('olympians')
+      .select('name', 'team', 'age', 'sport')
+      .groupBy('name', 'team', 'age', 'sport')
+      .count('medal as total_medals_won')
+      .orderBy('age')
+      .first()
+
+    return response;
+  } catch(err) {
+    return err;
+  }
+}
+
 router.get('/', (request, response) => {
   if(request.query.age === 'oldest') {
     oldestOlympian()
+      .then(olympians => {
+        if (olympians) {
+          var data = [olympians]
+          response.status(200).send({data})
+        } else {
+          response.status(404).json({
+            error: `No olympians found`
+          });
+        }
+      })
+  }
+  else if(request.query.age === 'youngest') {
+    youngestOlympian()
       .then(olympians => {
         if (olympians) {
           var data = [olympians]

--- a/tests/olympians.spec.js
+++ b/tests/olympians.spec.js
@@ -44,6 +44,13 @@ describe('Test GET api/v1/olympians', () => {
       expect(res.body.olympians[2]).toHaveProperty('total_medals_won')
       expect(res.body.olympians[2].total_medals_won).toBe('1')
     })
+      it('should generate error message for sad path', async() => {
+      await database('olympians').delete()
+      const res = await request(app).get("/api/v1/olympians")
+
+      expect(res.statusCode).toBe(404)
+      expect(res.body.error).toBe("No olympians found")
+    })
 
     it('should get oldest olympian', async() => {
 
@@ -66,8 +73,43 @@ describe('Test GET api/v1/olympians', () => {
 
       expect(res.body.data[0]).toHaveProperty('total_medals_won')
       expect(res.body.data[0].total_medals_won).toBe('1')
-
-
-
     })
+      it('should generate error message for sad path', async() => {
+      await database('olympians').delete()
+      const res = await request(app).get("/api/v1/olympians?age=oldest")
+
+      expect(res.statusCode).toBe(404)
+      expect(res.body.error).toBe("No olympians found")
+    })
+
+    it('should get youngest olympian', async() => {
+
+      const res = await request(app).get("/api/v1/olympians?age=youngest")
+
+      expect(res.statusCode).toBe(200)
+
+      expect(res.body.data[0]).toHaveProperty('name')
+      expect(res.body.data[0].name).toBe("You")
+
+      expect(res.body.data[0]).toHaveProperty('age')
+      expect(res.body.data[0].age).toBe(1)
+
+      expect(res.body.data[0]).toHaveProperty('team')
+      expect(res.body.data[0].team).toBe("Australia")
+
+
+      expect(res.body.data[0]).toHaveProperty('sport')
+      expect(res.body.data[0].sport).toBe("Running")
+
+      expect(res.body.data[0]).toHaveProperty('total_medals_won')
+      expect(res.body.data[0].total_medals_won).toBe('1')
+    })
+
+    it('should generate error message for sad path', async() => {
+    await database('olympians').delete()
+    const res = await request(app).get("/api/v1/olympians?age=youngest")
+
+    expect(res.statusCode).toBe(404)
+    expect(res.body.error).toBe("No olympians found")
+  })
 });


### PR DESCRIPTION
User can make a GET request to the endpoint api/v1/olympians?age=youngest.

- Adds conditional to olympians router api/v1/olympians?age=youngest to return youngest olympian
- Fully Tested
- Adds sad path testing for all api/v1/olympians endpoints(with an without query params)
- Test coverage at 93%

- Request
```
GET api/v1/olympians?age=youngest
```
- Successful Response
```
{
  [
    {
      "name": "Ana Iulia Dascl",
      "team": "Romania",
      "age": 13,
      "sport": "Swimming"
      "total_medals_won": 0
    }
  ]
}
```