### PR TITLE
Olympian Stats: GET /api/v1/olympian_stats

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const configuration = require('./knexfile')[environment];
 var indexRouter = require('./routes/index');
 // var papersRouter = require('./routes/api/v1/papers');
 var olympiansRouter = require('./routes/api/v1/olympians');
+var olympianStatsRouter = require('./routes/api/v1/olympian_stats');
 
 var app = express();
 
@@ -20,6 +21,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/api/v1/olympians', olympiansRouter);
+app.use('/api/v1/olympian_stats', olympianStatsRouter);
 
 
 module.exports = app;

--- a/models/olympian_stats.js
+++ b/models/olympian_stats.js
@@ -11,14 +11,28 @@ class OlympianStats {
     let statData = {}
     let olympianCount = await database('olympians').select('name', 'team', 'age', 'sport', 'sex', 'height', 'weight')
                               .groupBy('name', 'team', 'age', 'sport', 'sex', 'height', 'weight')
-    await console.log(olympianCount.length, "Olympian count")
     statData["total_competing_olympians"] = await olympianCount.length
 
     let avgAge = await database('olympians').avg('age')
     let formattedAvgAge = await parseFloat(avgAge[0]["avg"])
     let finalAvg = await Math.round(formattedAvgAge * 10) / 10;
     statData["average_age"] = await finalAvg
-    return statData
+    statData["average_weight"] = await {}
+    statData["average_weight"]["unit"] = "kg"
+
+    let maleAvgWeight = await database('olympians').where('sex', 'M').whereNotNull('weight').avg('weight')
+    let femaleAvgWeight = await database('olympians').where('sex', 'F').whereNotNull('weight').avg('weight')
+    let maleFormattedAvgWeight = await parseFloat(maleAvgWeight[0]["avg"])
+    let femaleFormattedAvgWeight = await parseFloat(femaleAvgWeight[0]["avg"])
+    let finalMaleAvg = await Math.round(maleFormattedAvgWeight * 10) / 10;
+    let finalFemaleAvg = await Math.round(femaleFormattedAvgWeight * 10) / 10;
+
+    statData["average_weight"]["male_olympians"] = await finalMaleAvg
+    statData["average_weight"]["female_olympians"] = await finalFemaleAvg
+
+    let finalStatData = {}
+    finalStatData["olympian_stats"] = await statData
+    return finalStatData
   }
 
 }

--- a/models/olympian_stats.js
+++ b/models/olympian_stats.js
@@ -1,0 +1,26 @@
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+class OlympianStats {
+
+  constructor() {
+  }
+
+  async makeStats() {
+    let statData = {}
+    let olympianCount = await database('olympians').select('name', 'team', 'age', 'sport', 'sex', 'height', 'weight')
+                              .groupBy('name', 'team', 'age', 'sport', 'sex', 'height', 'weight')
+    await console.log(olympianCount.length, "Olympian count")
+    statData["total_competing_olympians"] = await olympianCount.length
+
+    let avgAge = await database('olympians').avg('age')
+    let formattedAvgAge = await parseFloat(avgAge[0]["avg"])
+    let finalAvg = await Math.round(formattedAvgAge * 10) / 10;
+    statData["average_age"] = await finalAvg
+    return statData
+  }
+
+}
+
+module.exports = OlympianStats;

--- a/routes/api/v1/olympian_stats.js
+++ b/routes/api/v1/olympian_stats.js
@@ -1,0 +1,32 @@
+var express = require('express');
+var router = express.Router();
+
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../knexfile')[environment];
+const database = require('knex')(configuration);
+const fetch = require('node-fetch');
+
+
+async function allOlympians() {
+  try {
+    let response = await database('olympians')
+      .select('name', 'team', 'age', 'sport')
+      .groupBy('name', 'team', 'age', 'sport')
+      .count('medal as total_medals_won')
+    return response;
+  } catch(err) {
+    return err;
+  }
+}
+
+router.get('/', async function (request, response) {
+  await allOlympians()
+  .then((data) => {
+    response.status(200).json(data);
+  })
+  .catch((error) => {
+    return response.status(500).json({ error })
+  })
+})
+
+  module.exports = router;

--- a/routes/api/v1/olympian_stats.js
+++ b/routes/api/v1/olympian_stats.js
@@ -6,21 +6,13 @@ const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
 const fetch = require('node-fetch');
 
-
-async function allOlympians() {
-  try {
-    let response = await database('olympians')
-      .select('name', 'team', 'age', 'sport')
-      .groupBy('name', 'team', 'age', 'sport')
-      .count('medal as total_medals_won')
-    return response;
-  } catch(err) {
-    return err;
-  }
-}
+const OlympianStats = require('../../../models/olympian_stats')
+// const olympianData = OlympianStats.makeStats()
 
 router.get('/', async function (request, response) {
-  await allOlympians()
+  let olympianStatsModel = await new OlympianStats()
+  await olympianStatsModel.makeStats()
+  // console.log(olympianStatsModel)
   .then((data) => {
     response.status(200).json(data);
   })

--- a/tests/olympian_stats.spec.js
+++ b/tests/olympian_stats.spec.js
@@ -1,0 +1,43 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+
+describe('Test GET api/v1/olympian_stats', () => {
+  beforeEach(async () => {
+     await database.raw('truncate table olympians cascade');
+
+     await database('olympians').insert([
+     {name: 'You', sex: 'M', age: 1, height: 1680, weight: 55, team: 'Australia', games: '2016 Summer', sport: 'Running', event: "Running Fast", medal: 'Silver'},
+     {name: 'Someone Else', sex: 'F', age: 23, height: 168, weight: 55, team: 'Australia', games: '2016 Summer', sport: 'Running', event: "Running the Fastest", medal: 'Platinum'},
+     {name: 'Me', sex: 'F', age: 24, height: 168, weight: 65, team: 'Australia', games: '2016 Summer', sport: 'Running', event: "Running Fast", medal: 'Gold'}
+   ]);
+  });
+
+   afterEach(() => {
+     database.raw('truncate table olympians cascade');
+   });
+
+    it('should get olympian_stats', async() => {
+
+      const res = await request(app).get("/api/v1/olympian_stats")
+
+      expect(res.statusCode).toBe(200)
+
+      expect(res.body.olympian_stats).toHaveProperty('total_competing_olympians')
+      expect(res.body.olympian_stats['total_competing_olympians']).toBe(3)
+
+      expect(res.body.olympian_stats).toHaveProperty('average_age')
+      expect(res.body.olympian_stats.average_age).toBe(16)
+
+      expect(res.body.olympian_stats).toHaveProperty('average_weight')
+      expect(res.body.olympian_stats.average_weight['unit']).toBe("kg")
+      expect(res.body.olympian_stats.average_weight['male_olympians']).toBe(55)
+      expect(res.body.olympian_stats.average_weight['female_olympians']).toBe(60)
+    })
+
+});


### PR DESCRIPTION
User can make a GET request to api/v1/olympian_stats and receive statistics.

- Creates OlympianStats model to query olympians database and return formatted statistics
- Adds olympian_stats router with GET action
- Adds endpoint for olympian_stats in app.js

- A successful GET request will return a JSON response

- Request:
```
GET api/v1/olympian_stats
```
- Response
```
{
    "olympian_stats": {
      "total_competing_olympians": 3120
      "average_weight:" {
        "unit": "kg",
        "male_olympians": 75.4,
        "female_olympians": 70.2
      }
      "average_age:" 26.2
    }
  }
```