### PR TITLE
Events: /api/v1/events endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ var indexRouter = require('./routes/index');
 // var papersRouter = require('./routes/api/v1/papers');
 var olympiansRouter = require('./routes/api/v1/olympians');
 var olympianStatsRouter = require('./routes/api/v1/olympian_stats');
+var eventsRouter = require('./routes/api/v1/events');
 
 var app = express();
 
@@ -22,6 +23,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', indexRouter);
 app.use('/api/v1/olympians', olympiansRouter);
 app.use('/api/v1/olympian_stats', olympianStatsRouter);
+app.use('/api/v1/events', eventsRouter);
 
 
 module.exports = app;

--- a/db/migrations/20200114172539_events.js
+++ b/db/migrations/20200114172539_events.js
@@ -1,0 +1,25 @@
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.createTable('events', function(table) {
+      table.increments('id').primary();
+      table.string('name');
+      table.string('sex');
+      table.integer('age');
+      table.integer('height');
+      table.integer('weight');
+      table.string('team');
+      table.string('games');
+      table.string('sport');
+      table.string('event');
+      table.string('medal');
+
+      table.timestamps(true, true);
+    })
+  ])
+};
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.dropTable('events')
+  ])
+};

--- a/db/migrations/20200114173855_drop-events-columns.js
+++ b/db/migrations/20200114173855_drop-events-columns.js
@@ -1,0 +1,31 @@
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.table('events', function(table) {
+      table.dropColumn('name');
+      table.dropColumn('sex');
+      table.dropColumn('age');
+      table.dropColumn('height');
+      table.dropColumn('weight');
+      table.dropColumn('team');
+      table.dropColumn('games');
+      table.dropColumn('medal');
+
+    })
+  ])
+};
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.table('events', function(table) {
+
+      table.string('name');
+      table.string('sex');
+      table.integer('age');
+      table.integer('height');
+      table.integer('weight');
+      table.string('team');
+      table.string('games');
+      table.string('medal');
+    })
+  ])
+};

--- a/models/events.js
+++ b/models/events.js
@@ -1,0 +1,21 @@
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+class Events {
+
+  constructor() {
+  }
+
+  async getEvents() {
+    let sportData = await database('events').select('sport', database.raw('ARRAY_AGG(DISTINCT events.event) as events'))
+                          .groupBy('sport')
+    let eventData = {}
+    eventData["events"] = await sportData
+
+    return eventData
+  }
+
+}
+
+module.exports = Events;

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -1,0 +1,22 @@
+var express = require('express');
+var router = express.Router();
+
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../knexfile')[environment];
+const database = require('knex')(configuration);
+const fetch = require('node-fetch');
+
+const Events = require('../../../models/events')
+
+router.get('/', async function (request, response) {
+  let eventsModel = await new Events()
+  await eventsModel.getEvents()
+  .then((data) => {
+    response.status(200).json(data);
+  })
+  .catch((error) => {
+    return response.status(500).json({ error })
+  })
+})
+
+  module.exports = router;

--- a/tests/event.spec.js
+++ b/tests/event.spec.js
@@ -1,0 +1,38 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+
+describe('Test GET api/v1/events', () => {
+  beforeEach(async () => {
+     await database.raw('truncate table events cascade');
+
+     await database('events').insert([
+     {sport: 'Running', event: "Running Fast"},
+     {sport: 'Running', event: "Running the Fastest"},
+     {sport: 'Walking', event: "Speed Walking"}
+   ]);
+  });
+
+   afterEach(() => {
+     database.raw('truncate table events cascade');
+   });
+
+    it('should get events', async() => {
+
+      const res = await request(app).get("/api/v1/events")
+
+      expect(res.statusCode).toBe(200)
+
+      expect(res.body.events[0]).toHaveProperty('sport')
+      expect(res.body.events[0]['sport']).toBe("Running")
+
+      expect(res.body.events[0]).toHaveProperty('events')
+      expect(res.body.events[0].events[0]).toBe("Running Fast")
+    })
+
+});


### PR DESCRIPTION
User can make a GET request to the endpoint api/v1/events. 
- creates migration for events table
- creates event model to make database queries and format response
- Adds events router and action for GET request

- Request
```
GET api/v1/events
```
- Response
```
{
  "events":
    [
      {
        "sport": "Archery",
        "events": [
          "Archery Men's Individual",
          "Archery Men's Team",
          "Archery Women's Individual",
          "Archery Women's Team"
        ]
      },
      {
        "sport": "Badminton",
        "events": [
          "Badminton Men's Doubles",
          "Badminton Men's Singles",
          "Badminton Women's Doubles",
          "Badminton Women's Singles",
          "Badminton Mixed Doubles"
        ]
      },
      {...}
    ]
}
```